### PR TITLE
Correct`paper cut` ESC command to use nth vertical position.

### DIFF
--- a/src/buffer-builder.ts
+++ b/src/buffer-builder.ts
@@ -178,7 +178,7 @@ export class BufferBuilder {
    * @return BufferBuilder
    */
   public paperCut(): BufferBuilder {
-    this.buffer.write(Command.GS_v(66));
+    this.buffer.write(Command.GS_v(66,50));
     return this;
   }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -37,7 +37,7 @@ export class Command {
   public static GS_v0              = (m: number): number[] => [Command.GS, 0x76, 0x30, m]; // GSv0m
   public static GS_w               = (n: number): number[] => [Command.GS, 0x77, n]; // GSwn
   public static GS_x               = (n: number): number[] => [Command.GS, 0x78, n]; // GSxn
-  public static GS_v               = (n: number): number[] => [Command.GS, 0x56, n]; // GSv
+  public static GS_v               = (m: number, n: number): number[] => [Command.GS, 0x56, m, n]; // GSv
   public static ESC_ak             = (n: number): number[] => [Command.ESC, 0x2A, n]; // ESC*n
   public static ESC_akp             = (m: number, nL: number,nH: number ): number[] => [Command.ESC, 0x2A, m, nL, nH]; // ESC*n
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Prevent extra `{` to be printed on receipt due to cash drawer kick command 

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)
N/A