### PR TITLE
feat: parse tab in text node content

### DIFF
--- a/src/nodes/text-node.ts
+++ b/src/nodes/text-node.ts
@@ -14,7 +14,7 @@ export default class TextNode extends XMLNode {
       bufferBuilder.setCharacterSize(size[0], size[1]);
     }
 
-    let text = this.getContent().replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&#x3D;/g, '=').replace(/&#x2F;/g, '/').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&#39;/g, "'").replace(/&quot;/g, '"');
+    let text = this.getContent().replace(/&nbsp;/g, ' ').replace(/&lt;tab&gt;/g, '  ').replace(/&amp;/g, '&').replace(/&#x3D;/g, '=').replace(/&#x2F;/g, '/').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&#39;/g, "'").replace(/&quot;/g, '"');
 
     bufferBuilder.printText(text);
     return bufferBuilder;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Parse `tab` tag in text content to add 2 spaces
Example: 
text node:              `<tab><tab>this is a text`
printable output:   `    this is a text`

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)
