### PR TITLE
fix: expose printer reset control to clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "xml",
     "printer"
   ],
-  "version": "0.3.1",
+  "version": "0.3.2",
   "files": [
     "lib",
     "LICENSE",

--- a/src/buffer-builder.ts
+++ b/src/buffer-builder.ts
@@ -6,7 +6,7 @@ export class BufferBuilder {
   private hasGSCommand: boolean;
   private doEmphasise: boolean;
 
-  constructor(private defaultSettings: boolean = true) {
+  constructor(private shouldReset: boolean = true) {
     this.buffer = new MutableBuffer();
     this.hasGSCommand = true;
     this.doEmphasise = false;
@@ -198,8 +198,8 @@ export class BufferBuilder {
   }
 
   public build(): number[] {
-    if (this.defaultSettings) {
-      this.lineFeed();
+    this.lineFeed();
+    if (this.shouldReset) {
       this.buffer.write(Command.ESC_init);
     }
 

--- a/src/escpos.ts
+++ b/src/escpos.ts
@@ -4,18 +4,18 @@ import { BufferBuilder } from './buffer-builder';
 
 export class EscPos {
 
-  public static getBufferFromTemplate(template: string, data: any): number[] {
+  public static getBufferFromTemplate(template: string, data: any, shouldReset: boolean = true): number[] {
     let templateParser = new TemplateParser();
-    return templateParser.parser(template, data).build();
+    return templateParser.parser(template, data, shouldReset).build();
   }
 
-  public static getBufferFromXML(xml: string): number[] {
+  public static getBufferFromXML(xml: string, shouldReset: boolean = true): number[] {
     let xmlParser = new XMLParser();
-    return xmlParser.parser(xml).build();
+    return xmlParser.parser(xml, shouldReset).build();
   }
 
-  public static getBufferBuilder(): BufferBuilder {
-    return new BufferBuilder();
+  public static getBufferBuilder(shouldReset: boolean = true): BufferBuilder {
+    return new BufferBuilder(shouldReset);
   }
 
 }

--- a/src/template-parser.ts
+++ b/src/template-parser.ts
@@ -9,8 +9,8 @@ export class TemplateParser {
     this.mustache = Mustache;
   }
 
-  public parser(template, scope): BufferBuilder {
+  public parser(template, scope, shouldReset: boolean = true): BufferBuilder {
     const xml = this.mustache.render(template, scope);
-    return new XMLParser().parser(xml);
+    return new XMLParser().parser(xml, shouldReset);
   }
 }

--- a/src/xml-parser.ts
+++ b/src/xml-parser.ts
@@ -5,13 +5,13 @@ import { NodeFactory } from './node-factory';
 
 export class XMLParser {
 
-  public parser(xml: string): BufferBuilder {
+  public parser(xml: string, shouldReset: boolean = true): BufferBuilder {
     let parsedXML = parser(xml);
-    return this.compile(parsedXML);
+    return this.compile(parsedXML, shouldReset);
   }
 
-  private compile(parsedXML: any): BufferBuilder {
-    let bufferBuilder = new BufferBuilder();
+  private compile(parsedXML: any, shouldReset: boolean = true): BufferBuilder {
+    let bufferBuilder = new BufferBuilder(shouldReset);
     let rootNode = this.adapter(parsedXML.root, null);
     return rootNode.draw(bufferBuilder);
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Renamed `defaultSettings` to `shouldReset` for clarity and exposed it through public API methods. The ESC @ command (printer initialization) can now be controlled by callers, fixing issues when printing multiple jobs in quick succession.

Changes:
- Renamed parameter from `defaultSettings` to `shouldReset`
- Moved line feed outside conditional to always execute
- Exposed `shouldReset` parameter in all EscPos public methods
- Defaults to `true` for backward compatibility


## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)
