### PR TITLE
fix: move ESC_init to start of job

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "xml",
     "printer"
   ],
-  "version": "0.3.3",
+  "version": "0.3.4",
   "files": [
     "lib",
     "LICENSE",

--- a/src/buffer-builder.ts
+++ b/src/buffer-builder.ts
@@ -11,6 +11,9 @@ export class BufferBuilder {
     this.hasGSCommand = true;
     this.doEmphasise = false;
 
+    if (this.shouldReset) {
+      this.buffer.write(Command.ESC_init);
+    }
   }
 
   public end(): BufferBuilder {
@@ -199,10 +202,6 @@ export class BufferBuilder {
 
   public build(): number[] {
     this.lineFeed();
-    if (this.shouldReset) {
-      this.buffer.write(Command.ESC_init);
-    }
-
     return this.buffer.flush();
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Moved ESC_init command from end of build() to start of constructor. This prevents race condition where clearing receive buffer at job end would drop incoming data from the next job in high-volume printing.

Fixes buffer overflow issues on U220 printers while preventing dropped prints when shouldReset=true is used.



## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)
